### PR TITLE
Add support for expanding multiple substitutions

### DIFF
--- a/fontFeatures/feaLib/Substitution.py
+++ b/fontFeatures/feaLib/Substitution.py
@@ -13,11 +13,11 @@ def glyphref(g):
 def is_paired(self):
     # One of the substitution/replacements has all-but-one arity one,
     # and both arities are the same
-    self.input_lengths = [len(x) for x in self.input if len(x) != 1]
-    self.replacement_lengths = [len(x) for x in self.replacement if len(x) != 1]
-    if not (len(self.input_lengths) == 1 and len(self.replacement_lengths) ==1):
+    input_lengths = [len(x) for x in self.input if len(x) != 1]
+    replacement_lengths = [len(x) for x in self.replacement if len(x) != 1]
+    if not (len(input_lengths) == 1 and len(replacement_lengths) ==1):
         return False
-    if self.input_lengths[0] != self.replacement_lengths[0]:
+    if input_lengths[0] != replacement_lengths[0]:
         import warnings
         warnings.warn("Unbalanced paired substitution")
         return False
@@ -58,12 +58,15 @@ def paired_ligature(self):
 def paired_mult(self):
     b = feaast.Block()
 
-    if len(self.input_lengths) != 1:
+    input_lengths = [len(x) for x in self.input]
+    replacement_lengths = [len(x) for x in self.replacement]
+
+    if len(input_lengths) != 1:
         raise ValueError("Multiple substitution only valid on input of length one, use a Chain instead")
 
-    input_length = self.input_lengths[0]
+    input_length = input_lengths[0]
 
-    if not sum([l for l in self.replacement_lengths if l == 1]) in [len(self.replacement_lengths), len(self.replacement_lengths)-1]:
+    if not sum([l for l in replacement_lengths if l == 1]) in [len(replacement_lengths), len(replacement_lengths)-1]:
         raise ValueError("Cannot expand multiple glyph classes in a multiple substitution — creates ambiguity")
 
     # Look for the glyph class in the replacement, or default to first glyph in replacement

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -34,6 +34,18 @@ class TestSubstitution(unittest.TestCase):
         self.assertEqual(s.involved_glyphs, set(["a", "b", "c"]))
         self.roundTrip(s)
 
+    def test_multiple_expansion(self):
+        s = Substitution([["a", "b"]], [["a", "b"], "c"])
+        self.assertEqual(s.asFea(), "    sub a by a c;\n    sub b by b c;\n")
+        self.assertEqual(s.involved_glyphs, set(["a", "b", "c"]))
+        self.roundTrip(s)
+
+    def test_multiple_expansion_middle(self):
+        s = Substitution([["a", "b"]], ["d", ["a", "b"], "c"])
+        self.assertEqual(s.asFea(), "    sub a by d a c;\n    sub b by d b c;\n")
+        self.assertEqual(s.involved_glyphs, set(["a", "b", "c", "d"]))
+        self.roundTrip(s)
+
     def test_alternate(self):
         s = Substitution(["a"], [["b", "c"]])
         self.assertEqual(s.asFea(), "sub a from [b c];")


### PR DESCRIPTION
Close #13

I'm going to be honest @simoncozens, this is where we start to run into the limits of my programming abilities, especially on other people's libraries.

This solves _my case_. Does it solve all mult subs? I think you have more implementation experience and should carefully check.

```fea
DefineClass @Tlower = [a b c d e f g h i j k l m n o p q r s t u v w x y z];
DefineClass @Tlower_low = [a.low b.low c.low d.low e.low f.low g.low h.low i.low j.low k.low l.low m.low n.low o.low p.low q.low r.low s.low t.low u.low v.low w.low x.low y.low z.low];

Feature rclt {
	Substitute @Tlower -> $1.low tail.low;
	#Substitute a -> b;
};
```

```fea
@Tlower = [a b c d e f g h i j k l m n o p q r s t u v w x y z];
@Tlower_low = [a.low b.low c.low d.low e.low f.low g.low h.low i.low j.low k.low l.low m.low n.low o.low p.low q.low r.low s.low t.low u.low v.low w.low x.low y.low z.low];

feature rclt {
    lookup Routine_1 {
        ;
                    sub a by a.low tail.low;
            sub b by b.low tail.low;
            sub c by c.low tail.low;
            sub d by d.low tail.low;
            sub e by e.low tail.low;
            sub f by f.low tail.low;
            sub g by g.low tail.low;
            sub h by h.low tail.low;
            sub i by i.low tail.low;
            sub j by j.low tail.low;
            sub k by k.low tail.low;
            sub l by l.low tail.low;
            sub m by m.low tail.low;
            sub n by n.low tail.low;
            sub o by o.low tail.low;
            sub p by p.low tail.low;
            sub q by q.low tail.low;
            sub r by r.low tail.low;
            sub s by s.low tail.low;
            sub t by t.low tail.low;
            sub u by u.low tail.low;
            sub v by v.low tail.low;
            sub w by w.low tail.low;
            sub x by x.low tail.low;
            sub y by y.low tail.low;
            sub z by z.low tail.low;

    } Routine_1;

} rclt;
```