### PR TITLE
-“language” from acronym explanation

### DIFF
--- a/fontFeatures/__init__.py
+++ b/fontFeatures/__init__.py
@@ -7,8 +7,8 @@ either "compiled down" into AFDKO feature code or directly written to the
 GSUB/GPOS tables of a font.
 
 FontFeatures aims to marshal data between OTF binary representations,
-AFDKO feature code, FontDame, and a new language called FEE (Font
-Engineering language with Extensibility).
+AFDKO feature code, FontDame, and a new language called the FEE (Font
+Engineering with Extensibility) language.
 
 A FontFeatures representation of a font will make use of two other top-level
 concepts: Features and Routines. Routines are collections of rules; they play


### PR DESCRIPTION
Sorry, this is small, but it really bothers me. 

It's not «FELE» :no_entry_sign: :no_good:…
it's «FEE»! :tada: