### PR TITLE
Expand multiple equal length classes in a liga sub

### DIFF
--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -28,6 +28,12 @@ class TestSubstitution(unittest.TestCase):
         self.assertEqual(s.involved_glyphs, set(["a", "b", "c"]))
         self.roundTrip(s)
 
+    def test_ligature_expansion(self):
+        s = Substitution([["f", "f.ss01"], ["i", "i.ss01"]], [["f_i", "f_i.ss01"]])
+        self.assertEqual(s.asFea(), "    sub f i by f_i;\n    sub f.ss01 i.ss01 by f_i.ss01;\n")
+        self.assertEqual(s.involved_glyphs, set(["f", "i", "f_i", "f.ss01", "i.ss01", "f_i.ss01"]))
+        self.roundTrip(s)
+
     def test_multiple(self):
         s = Substitution(["a"], ["b", "c"])
         self.assertEqual(s.asFea(), "sub a by b c;")


### PR DESCRIPTION
Right now, `Substitute [f f.ss01] i -> [f_i f_i.ss01]` expands to:
```fea
sub f i -> f_i;
sub f.ss01 i -> f_i.ss01;
```

However, `Substitute [f f.ss01] [i i.ss01] -> [f_i f_i.ss01]` doesn't expand to
```fea
sub f i -> f_i;
sub f.ss01 i.ss01 -> f_i.ss01;
```

It instead generates invalid OpenType code:

```fea
# Won't work
sub [f f.ss01] [i i.ss01] by [f_i f_i.ss01];
```

Per your thought that FEE «will work out the best way to express the user's (high-level) intention in terms of those low-level instructions» (expressed in https://github.com/simoncozens/fontFeatures/pull/14#discussion_r568472159), it seems very intuitive to me that this type of ligature substitution should be allowed.

It only triggers if all glyph classes are equal in length, otherwise intolerable ambiguity would result and no compilation should happen. Also, I was careful to assure that expansions in the case of a single replacement glyph still happen as before.

Closes #19.