### PR TITLE
Correct hasglyph predicate for changed barename

### DIFF
--- a/fontFeatures/feeLib/ClassDefinition.py
+++ b/fontFeatures/feeLib/ClassDefinition.py
@@ -109,7 +109,7 @@ import warnings
 GRAMMAR = """
 comp_predicate = 'not'?:n ws  '(' ws <letter+>:metric ws ('>='|'<='|'='|'<'|'>'):comparator ws (<digit+>|bracketed_metric):value ws ')' -> {'predicate': metric, 'comparator': comparator, 'value': value, 'inverted': n}
 has_anchor_predicate = 'not'?:n ws 'hasanchor(' barename:anchor ')' -> {'predicate': 'hasanchor', 'value': anchor["barename"], 'inverted':n }
-has_glyph_predicate = 'not'?:n ws 'hasglyph(' regex:replace ws barename:withs ')' -> {'predicate': 'hasglyph', 'value': {'replace': replace["regex"], 'with': withs["barename"]}, 'inverted':n }
+has_glyph_predicate = 'not'?:n ws 'hasglyph(' regex:replace ws <midglyphname+>:withs ')' -> {'predicate': 'hasglyph', 'value': {'replace': replace["regex"], 'with': withs}, 'inverted':n }
 predicate = ws 'and' ws ( has_glyph_predicate | category_predicate | has_anchor_predicate | comp_predicate )
 category_predicate = 'not'?:n ws 'category(' barename:cat ')' -> {'predicate': 'category', 'value': cat["barename"], 'inverted':n }
 bracketed_metric = <letter+>:metric '(' <(letter|digit|"."|"_")+>:glyph ')' -> {'metric': metric, 'glyph': glyph}


### PR DESCRIPTION
The commit cc5dcb8055f4e92f096dc1907e2de0355ce84535 changed the definition of `barename` such that `.` could no longer come first. This breaks `hasglyph` predicate in certain cases, which assumes that you can use any string allowable in a glyphname.

Example of a now broken case which worked before:

```
DefineClass @sc_and_alt_able = /./ and hasglyph(/$/ .alt) and hasglyph(/$/ .sc);
```