### PR TITLE
Fix mult sub expansion of glyphs when name len > 1

### DIFF
--- a/fontFeatures/feaLib/Substitution.py
+++ b/fontFeatures/feaLib/Substitution.py
@@ -83,9 +83,9 @@ def paired_mult(self):
     for f, t in zipped:
         stmt = feaast.MultipleSubstStatement(
             [glyphref(x) for x in self.precontext],
-            glyphref(f),
+            glyphref([f]),
             [glyphref(x) for x in self.postcontext],
-            [glyphref(g) for g in prior_reps+[t]+after_reps]
+            [glyphref(g) for g in prior_reps+[[t]]+after_reps]
         )
         b.statements.append(stmt)
 

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -41,9 +41,9 @@ class TestSubstitution(unittest.TestCase):
         self.roundTrip(s)
 
     def test_multiple_expansion_middle(self):
-        s = Substitution([["a", "b"]], ["d", ["a", "b"], "c"])
-        self.assertEqual(s.asFea(), "    sub a by d a c;\n    sub b by d b c;\n")
-        self.assertEqual(s.involved_glyphs, set(["a", "b", "c", "d"]))
+        s = Substitution([["aa", "bb"]], ["d", ["aa", "bb"], "c"])
+        self.assertEqual(s.asFea(), "    sub aa by d aa c;\n    sub bb by d bb c;\n")
+        self.assertEqual(s.involved_glyphs, set(["aa", "bb", "c", "d"]))
         self.roundTrip(s)
 
     def test_alternate(self):


### PR DESCRIPTION
I consider merging this somewhat urgent.

This is one of those things I am ashamed to admit I didn't notice...until I started using it in production without one-letter long test glyphs.

Yes, this was coming out of `fee2fea`:

```fea
sub [u n i 2 4 7 4] by parenleft [o n e] parenright;
sub [u n i 2 4 7 C] by parenleft [n i n e] parenright;
```

Totally my fault. Sorry. It's the little things. I made one of the tests a little better so it would now catch this, not that it'll ever come up again.