### PR TITLE
Use Lark parser

### DIFF
--- a/fontFeatures/feeLib/Chain.py
+++ b/fontFeatures/feeLib/Chain.py
@@ -12,33 +12,60 @@ Examples::
 """
 
 import fontFeatures
+from .Substitute import BASE_GRAMMAR, Substitute_GRAMMAR, Substitute
+from .util import extend_args_until
 
-GRAMMAR = """
-Chain_Args = normal_chain_args | contextual_chain_args
+PARSEOPTS = dict(use_helpers=True)
 
-normal_chain_args = gsluws+:stuff languages?:languages -> (stuff,languages, [], [])
-contextual_chain_args =  gsws*:pre '{' gsluws+:stuff languages?:languages '}' ws gsws*:post -> (stuff,languages, pre, post)
-gsluws = glyphselector:g ws lookup_list?:l ws -> (g,l)
-lookup_list = '(' ws lookups:l ws ')' -> l
-lookups = lookup*
-lookup = barename:b ws? ','? -> b["barename"]
-languages = '<' lang '/' script (ws ',' ws lang '/' script)* '>' ws
-lang = letter{3,4} | '*' # Fix later
-script = letter{3,4} | '*' # Fix later
+Chain_GRAMMAR = Substitute_GRAMMAR
+
+GRAMMAR = BASE_GRAMMAR+"""
+lookup: "^" BARENAME ","?
+lookups: lookup*
+gslu: glyphselector lookups
+
+normal_action: gslu+ languages?
+contextual_action: pre "(" normal_action ")" post
 """
 
 VERBS = ["Chain"]
 
-class Chain:
-    @classmethod
-    def action(self, parser, stuff, languages, pre, post):
-        inputs  = [x[0].resolve(parser.fontfeatures, parser.font) for x in stuff]
+class Chain(Substitute):
+    def lookups(self, args):
+        return args
+
+    def gslu(self, args):
+        # If no lookup list, append a None
+        if len(args) == 1:
+            args.append(None)
+        return args
+
+    def lookup(self, args):
+        (lookupname,) = args
+
+        return lookupname.value
+
+    def contextual_action(self, args):
+        args = extend_args_until(args, 4)
+        (pre, stuff, languages, post) = args
+        args = [stuff, languages, pre, post]
+        return args
+
+    def normal_action(self, args):
+        return args
+
+    # stuff, languages, pre, post
+    def action(self, args):
+        # `stuff` are tuples of (glyphselector, lookup_list)
+        (stuff, languages, pre, post) = args[0]
+
+        inputs  = [x[0].resolve(self.parser.fontfeatures, self.parser.font) for x in stuff]
         lookupnames = [x[1] or [] for x in stuff]
         lookups = []
         for lu in lookupnames:
             lookups.append([fontFeatures.RoutineReference(name=x) for x in lu])
-        pre     = [g.resolve(parser.fontfeatures, parser.font) for g in pre]
-        post     = [g.resolve(parser.fontfeatures, parser.font) for g in post]
+        pre     = [g.resolve(self.parser.fontfeatures, self.parser.font) for g in pre]
+        post     = [g.resolve(self.parser.fontfeatures, self.parser.font) for g in post]
         languages = None # For now
         return [fontFeatures.Chaining(inputs, lookups = lookups,
             precontext = pre,

--- a/fontFeatures/feeLib/Conditional.py
+++ b/fontFeatures/feeLib/Conditional.py
@@ -14,43 +14,59 @@ Examples::
 """
 
 import fontFeatures
+from .util import compare
+from . import HelperTransformer
+
+PARSEOPTS = dict(use_helpers=True)
 
 GRAMMAR = """
-If_Args = boolean_condition:c wsc '{' wsc statement+:s wsc '}' -> (c,s)
-boolean_condition = or | and | boolean_term
-boolean_term = bracketed | not | boolean_factor
-boolean_factor = integer:l ws comparison?:r -> parser.plugin_classes["If"].docomparison(l,r)
-comparison = ('>='|'>'|'<='|'<'|'=='|'!='):cmp ws integer:r -> (cmp,r)
-not = "not" ws boolean_condition:b -> not bool(b)
-bracketed = "(" ws boolean_condition:b ws ")" -> b
-or = boolean_term:a ws "or" ws boolean_term:b -> (a or b)
-and = boolean_term:a ws "and" ws boolean_term:b -> (a and b)
+boolean_condition: comparison | (boolean_term | not_boolean_term)
+boolean_term: integer_container COMPARATOR integer_container
+not_boolean_term: "not" boolean_term
+comparison: (boolean_term | not_boolean_term) AND_OR (boolean_term | not_boolean_term)
+AND_OR: ("&" | "|")
+"""
+
+If_GRAMMAR = """
+?start: action
+action: boolean_condition "{" statement+ "}"
+"""
+
+If_beforebrace_GRAMMAR = """
+?start: beforebrace
+beforebrace: boolean_condition
 """
 
 VERBS = ["If"]
 
-class If:
-    @classmethod
-    def action(self, parser, condition, statements):
-        if bool(condition):
-            return parser.filterResults(statements)
+class If(HelperTransformer):
+    def __init__(self, parser):
+        self.parser = parser
+
+    def comparison(self, args):
+        (l, comparator, r) = args
+        if comparator.value == "&":
+            return l and r
+        elif comparator.value == "|":
+            return l or r
+        else:
+            raise ValueError("Unrecognized comparator")
+
+    def boolean_term(self, args):
+        (l, comparator, r) = args
+        return compare(l, comparator, r)
+
+    def boolean_condition(self, args):
+        return args[0]
+
+    def not_boolean_term(self, args):
+        (boolean_term,) = args
+        return not boolean_term
+
+    def action(self, args):
+        (boolean, statements, _) = args
+
+        if bool(boolean):
+            return statements
         else:
             return []
-
-    @classmethod
-    def docomparison(self, l,r):
-        if not r:
-            return bool(l)
-        left,operator, right = l,r[0],r[1]
-        if operator == "<":
-            return left < right
-        if operator == "<=":
-            return left < right
-        if operator == "==":
-            return left == right
-        if operator == ">":
-            return left > right
-        if operator == ">=":
-            return left >= right
-        if operator == "!=":
-            return left != right

--- a/fontFeatures/feeLib/Debug.py
+++ b/fontFeatures/feeLib/Debug.py
@@ -1,0 +1,40 @@
+import warnings
+
+from . import HelperTransformer
+from fontFeatures.feeLib import GlyphSelector
+
+PARSEOPTS = dict(use_helpers=True)
+GRAMMAR = ""
+ShowClass_GRAMMAR = """
+?start: action
+action: glyphselector
+"""
+DumpClassNames_GRAMMAR = DumpClasses_GRAMMAR = """
+?start: action
+action:
+"""
+VERBS = ["ShowClass", "DumpClassNames", "DumpClasses"]
+
+class DumpClasses(HelperTransformer):
+    def action(self, _):
+        for c in self.parser.fontfeatures.namedClasses:
+            ShowClass(self.parser).action((GlyphSelector({"classname":c}, [], None),))
+        return
+
+class DumpClassNames(HelperTransformer):
+    def action(self, _):
+        warnings.warn(" ".join(self.parser.fontfeatures.namedClasses))
+
+        return
+
+class ShowClass(HelperTransformer):
+    def action(self, args):
+        (classname,) = args
+        warnings.warn(
+            "%s = %s"
+            % (
+                classname.as_text(),
+                " ".join(classname.resolve(self.parser.fontfeatures, self.parser.font)),
+            )
+        )
+        return

--- a/fontFeatures/feeLib/Feature.py
+++ b/fontFeatures/feeLib/Feature.py
@@ -11,41 +11,75 @@ a name and a block containing rules::
 
 Note that in FEE syntax you must not repeat the feature name at the end of
 the block, as is required in AFDKO syntax.
+
+For some features, like the Stylistic Sets (``ss01``-``ss20``), you can specify
+a ``FeatureName``. If supported by the software it's displayed to the user::
+
+    Feature ss01 {
+        FeatureName "Half-width hiragana";
+        ....
+    };
 """
 
 GRAMMAR = """
-Feature_Args = featurename:f wsc '{' wsc statement+:s '}' -> (f,s)
-FeatureName_Args = '"' <~'"' anything >+:name '"' -> (name,)
-
-featurename = <letter (letter|digit){3}>
+FEATURENAME: LETTER (LETTER | DIGIT)~3
 """
-VERBS = ["Feature", "FeatureName"]
 
-from fontFeatures import Routine
+Feature_GRAMMAR = """
+?start: action
+action: FEATURENAME "{" statement+ "}"
+"""
 
-class Feature:
-    @classmethod
-    def action(self, parser, featurename, statements):
-        results = parser.filterResults(statements)
-        parser.current_feature = featurename
+Feature_beforebrace_GRAMMAR = """
+?start: beforebrace
+beforebrace: FEATURENAME
+"""
+#FeatureName_Args = '"' <~'"' anything >+:name '"' -> (name,)
+
+#featurename = <letter (letter|digit){3}>
+#"""
+PARSEOPTS = dict(use_helpers=True)
+VERBS = ["Feature"]#, "FeatureName"]
+
+from . import HelperTransformer
+from fontFeatures import Routine, Rule
+
+class Feature(HelperTransformer):
+    def FEATURENAME(self, tok):
+        return tok.value
+
+    def beforebrace(self, args):
+        return args
+
+    def action(self, args):
+        (featurename, statements, _) = args
+        featurename = featurename[0]
+
+        results = self.parser.filterResults(statements)
+        self.parser.current_feature = featurename
         oddStatements = []
         def wrap_and_flush():
-          nonlocal oddStatements
-          if len(oddStatements) > 0:
-            parser.fontfeatures.addFeature(featurename, [Routine(rules=oddStatements)])
-          oddStatements = []
+            nonlocal oddStatements
+            
+            if len(oddStatements) > 0:
+                self.parser.fontfeatures.addFeature(featurename, [Routine(rules=[r for r in oddStatements if isinstance(r, Rule)])])
+            oddStatements = []
 
         for r in results:
-          if isinstance(r, Routine):
-            wrap_and_flush()
-            parser.fontfeatures.addFeature(featurename, [r])
-          else:
-            oddStatements.append(r)
+            if isinstance(r, Routine):
+                wrap_and_flush()
+                self.parser.fontfeatures.addFeature(featurename, [r])
+            else:
+                oddStatements.append(r)
+
         wrap_and_flush()
-        parser.current_feature = None
+        self.parser.current_feature = None
 
+        return statements
 
+"""
 class FeatureName:
     @classmethod
     def action(self, parser, name):
       pass
+"""

--- a/fontFeatures/feeLib/Include.py
+++ b/fontFeatures/feeLib/Include.py
@@ -8,11 +8,15 @@ verb::
     Include anchors.fee;
 """
 
+from . import HelperTransformer
+import lark
+
 import os
 
+PARSEOPTS = dict(use_helpers=True)
 GRAMMAR = """
-Include_Args = <(~';' anything)+>:filename -> (filename,)
-IncludeFEA_Args = Include_Args
+?start: action
+action: ESCAPED_STRING
 """
 VERBS = ["Include", "IncludeFEA"]
 
@@ -26,15 +30,18 @@ def _file_to_string_or_error(parser, filename):
                 return f.read()
     raise ValueError("Could not include file %s" % filename)
 
-class Include:
-    @classmethod
-    def action(self, parser, filename):
-        return parser.parseString(_file_to_string_or_error(parser, filename))
+class Include(HelperTransformer):
+    def ESCAPED_STRING(self, tok):
+        return tok.value[1:-1] # slice removes "'s
+
+    def action(self, args):
+        (filename,) = args
+        return self.parser.parseString(_file_to_string_or_error(self.parser, filename))
 
 from fontFeatures.feaLib import FeaUnparser
 
-class IncludeFEA:
-    @classmethod
-    def action(self, parser, filename):
-        fea = FeaUnparser(_file_to_string_or_error(parser, filename))
-        parser.fontfeatures += fea.ff
+class IncludeFEA(Include):
+    def action(self, args):
+        (filename,) = args
+        fea = FeaUnparser(_file_to_string_or_error(self.parser, filename))
+        self.parser.fontfeatures += fea.ff

--- a/fontFeatures/feeLib/LoadPlugin.py
+++ b/fontFeatures/feeLib/LoadPlugin.py
@@ -1,26 +1,21 @@
-"""
-Loading Plugins
-===============
+import lark
 
-Additional functionality is provided by plugins, which register additional
-FEE verbs. To load a plugin, use the ``LoadPlugin`` verb. This takes
-the name of a Python module. If the name does *not* contain a period character,
-the plugin is expected to be found under the ``fontFeatures.feeLib`` package::
-
-    LoadPlugin IMatra; # Loads the plugin fontFeatures.feeLib.IMatra
-
-To load a custom plugin of your own, specify a Python module with a period in
-the name::
-
-    LoadPlugin myTools.myFEEPlugin; # Loads myTools.myFEEPlugin
-
-"""
+PARSEOPTS = dict(use_helpers=True)
 
 GRAMMAR = """
-LoadPlugin_Args = <(letter|".")+>:x -> [x]
+    ?start: action
+    action: VERB
+
+    %import common(WS, LETTER, DIGIT)
+    %ignore WS
 """
+
 VERBS = ["LoadPlugin"]
-class LoadPlugin:
-    @classmethod
-    def action(self, parser, name):
-        parser._load_plugin(name)
+
+class LoadPlugin(lark.Transformer):
+    def __init__(self, parser):
+        self.parser = parser
+
+    def action(self, args):
+        self.parser.load_plugin(args[0].value)
+        return args[0].value

--- a/fontFeatures/feeLib/Position.py
+++ b/fontFeatures/feeLib/Position.py
@@ -33,21 +33,19 @@ Here are examples of each form of the positioning verb::
 """
 
 from fontFeatures import Positioning, ValueRecord
+from .Substitute import BASE_GRAMMAR, Substitute_GRAMMAR, Substitute
+from .util import extend_args_until
 
+PARSEOPTS = dict(use_helpers=True)
 
-GRAMMAR = """
-Position_Args = context_pos_args | normal_pos_args
+Position_GRAMMAR = Substitute_GRAMMAR
 
-normal_pos_args = gsposws+:g_ps  languages?:languages -> (g_ps,languages, [], [])
-context_pos_args = gsws*:pre '{' ws gsposws+:g_ps2 ws '}' ws gsws*:post languages?:languages -> (g_ps2,languages, pre, post)
-
-gsposws = glyphselector:g ws valuerecord?:v ws? -> (g,v)
-gsws = glyphselector:g ws? -> g
-
-languages = '<' lang '/' script (ws ',' ws lang '/' script)* '>' ws
-lang = letter{3,4} | '*' # Fix later
-script = letter{3,4} | '*' # Fix later
-
+GRAMMAR = BASE_GRAMMAR+"""
+gspos: glyphselector valuerecord?
+gsposes: gspos+
+normal_action: gsposes maybe_languages
+maybe_languages: languages?
+contextual_action: pre "(" normal_action ")" post
 """
 
 VERBS = ["Position"]
@@ -60,15 +58,49 @@ def makeValueRecord(valuerecord):
         setattr(v,k["dimension"],k["position"])
     return v
 
-class Position:
-    @classmethod
-    def action(self, parser, l, languages, pre, post):
+class Position(Substitute):
+    def contextual_action(self, args):
+        args = extend_args_until(args, 4)
+        (pre, stuff, languages, post) = args
+        args = [stuff, languages, pre, post]
+        return args
+
+    def normal_action(self, args):
+        return args
+
+    def valuerecord(self, args):
+        return args[0]
+
+    fea_value_record = normal_action
+    maybe_languages = normal_action
+    gsposes = normal_action
+
+    def fee_value_record(self, args):
+        ret = []
+        while len(args) > 0:
+            verb = args.pop(0)
+            value = args.pop(0)
+            ret.append({"dimension": verb, "position": value})
+
+        return {"members": ret}
+
+    def gspos(self, args):
+        # If no valuerecord, append a None
+        if len(args) == 1:
+            args.append(None)
+        return args
+
+    def action(self, args):
+        args = args[0]
+        args = extend_args_until(args, 4)
+        (l, languages, pre, post) = args
+
         inputs = []
         valuerecords = []
-        pre     = [g.resolve(parser.fontfeatures, parser.font) for g in pre]
-        post     = [g.resolve(parser.fontfeatures, parser.font) for g in post]
+        pre     = [g.resolve(self.parser.fontfeatures, self.parser.font) for g in pre]
+        post     = [g.resolve(self.parser.fontfeatures, self.parser.font) for g in post]
         for glyphselector, valuerecord in l:
-            inputs.append(glyphselector.resolve(parser.fontfeatures, parser.font))
+            inputs.append(glyphselector.resolve(self.parser.fontfeatures, self.parser.font))
             if valuerecord:
                 valuerecords.append(makeValueRecord(valuerecord))
             else:

--- a/fontFeatures/feeLib/Routine.py
+++ b/fontFeatures/feeLib/Routine.py
@@ -22,51 +22,96 @@ may find it less surprising to place all rulesets within a feature within their
 own routines as well, due to the way that OpenType orders lookups for processing.
 """
 
+PARSEOPTS = dict(use_helpers=True)
+
 GRAMMAR = """
-Routine_Args = routinename?:f wsc routine_tail?:tail wsc -> (f,tail)
-routine_tail =  '{' wsc statement+:s '}' wsc flag*:flags -> (s, flags)
-
-routinename = <(letter|digit|"_")+>
-
-rl  = "RightToLeft"         -> 0x1
-ib  = "IgnoreBases"         -> 0x2
-il  = "IgnoreLigatures"     -> 0x4
-im  = "IgnoreMarks"         -> 0x8
-mat = "MarkAttachmentType"  -> 0xFF00
-umf = "UseMarkFilteringSet" -> 0x10
-flag = ( rl | ib | il | im |  complexflag):f ws -> f
-complexflag = (umf|mat):value ws glyphselector:gs -> (value,gs)
+SIMPLE_FLAG: "RightToLeft" | "IgnoreBases" | "IgnoreLigatures" | "IgnoreMarks"
+COMPLEX_FLAG: "MarkAttachmentType" | "UseMarkFilteringSet"
+complexflag: COMPLEX_FLAG glyphselector
+flag: SIMPLE_FLAG | complexflag
+flags: flag*
+ROUTINENAME: (LETTER|DIGIT|"_")+
 """
+
+Routine_GRAMMAR = """
+?start: action
+action: ROUTINENAME? "{" statement+ "}" flags
+"""
+
+Routine_beforebrace_GRAMMAR = """
+?start: beforebrace
+beforebrace: ROUTINENAME?
+"""
+
+Routine_afterbrace_GRAMMAR = """
+?start: afterbrace
+afterbrace: flags
+"""
+
 VERBS = ["Routine"]
 
-import fontFeatures
+FLAGS = {
+    "RightToLeft": 0x1,
+    "IgnoreBases": 0x2,
+    "IgnoreLigatures": 0x4,
+    "IgnoreMarks": 0x8,
+    "MarkAttachmentType": 0xFF00,
+    "UseMarkFilteringSet": 0x10
+}
 
-class Routine:
-    @classmethod
-    def action(self, parser, routinename, tail):
-        if not tail:
+import fontFeatures
+from . import HelperTransformer
+
+class Routine(HelperTransformer):
+    def beforebrace(self, args):
+        return args
+
+    def afterbrace(self, args):
+        return args[0]
+    
+    flags = beforebrace
+
+    def complexflag(self, args):
+        return (FLAGS[args[0].value], args[1])
+
+    def flag(self, args):
+        (flag,) = args
+
+        if isinstance(flag, str):
+            return FLAGS[flag]
+        elif isinstance(flag, tuple):
+            return flag
+
+    def action(self, args):
+        (routinename, statements, flags) = args
+
+        if routinename is not None:
+            routinename = routinename[0].value
+
+        if flags is None: flags = []
+
+        if not statements:
             rr = fontFeatures.RoutineReference(name = routinename)
             return [rr]
-        statements, flags = tail;
         r = fontFeatures.Routine()
         if routinename:
-          r.name = routinename
+            r.name = routinename
         r.rules = []
-        for res in parser.filterResults(statements):
-          if isinstance(res, fontFeatures.Routine):
-            r.rules.extend(res.rules)
-          else:
-            r.rules.append(res)
+        for res in self.parser.filterResults(statements):
+            if isinstance(res, fontFeatures.Routine):
+                r.rules.extend(res.rules)
+            else:
+                r.rules.append(res)
         r.flags = 0
         for f in flags:
-          if isinstance(f, tuple):
-            r.flags |= f[0]
-            if f[0] == 0x10:
-              r.markFilteringSet = f[1].resolve(parser.fontfeatures, parser.font)
-            elif f[0] == 0xFF00:
-              r.markAttachmentSet = f[1].resolve(parser.fontfeatures, parser.font)
-          else:
-            r.flags |= f
-        if not parser.current_feature:
-          parser.fontfeatures.routines.append(r)
+            if isinstance(f, tuple):
+                r.flags |= f[0]
+                if f[0] == 0x10:
+                    r.markFilteringSet = f[1].resolve(self.parser.fontfeatures, self.parser.font)
+                elif f[0] == 0xFF00:
+                    r.markAttachmentSet = f[1].resolve(self.parser.fontfeatures, self.parser.font)
+            else:
+                r.flags |= f
+        if not self.parser.current_feature:
+            self.parser.fontfeatures.routines.append(r)
         return [r]

--- a/fontFeatures/feeLib/Variables.py
+++ b/fontFeatures/feeLib/Variables.py
@@ -5,22 +5,28 @@ Variables
 Numbers can be stored in variables using the ``Set`` verb.
 
 Examples::
-
     Set $spacing = 150;
     Position A $spacing B;
 
 """
 
-import fontFeatures
+import lark
+
+PARSEOPTS = dict(use_helpers=True)
 
 GRAMMAR = """
-Set_Args = '$' barename:b ws '=' ws integer:v -> (b,v)
+    ?start: action
+    action: BARENAME "=" SIGNED_NUMBER
+
+    %ignore WS
 """
 
 VERBS = ["Set"]
 
-class Set:
-    @classmethod
-    def action(self, parser, b,v):
-        parser.variables[b["barename"]] = v
-        return []
+class Set(lark.Transformer):
+    def __init__(self, parser):
+        self.parser = parser
+
+    def action(self, args):
+        self.parser.variables[args[0].value] = args[1].value
+        return (args[0].value, args[1].value)

--- a/fontFeatures/feeLib/__init__.py
+++ b/fontFeatures/feeLib/__init__.py
@@ -1,184 +1,87 @@
-import re
-import parsley
-import importlib, inspect
-from fontFeatures import FontFeatures
-from babelfont.font import Font
-from ometa.grammar import OMeta
+import lark
+
+import collections
+import pathlib
 import warnings
+
+from importlib import import_module
+from fontFeatures import FontFeatures
+from fontFeatures.feeLib import GlyphSelector
+from babelfont.font import Font
 from more_itertools import collapse
 
+GRAMMAR="""
+    ?start: statement+
 
-def warning_on_one_line(message, category, filename, lineno, file=None, line=None):
-    return "# %s\n" % (message)
-
-
-warnings.formatwarning = warning_on_one_line
-
-
-def callRule(self):
-    _locals = {"self": self}
-    n1 = self._apply(self.rule_anything, "anything", [])
-    n2 = self._apply(self.rule_anything, "anything", [])
-    return self.foreignApply(n1[0], n1[0] + "_" + n2[0], self.globals, self.locals)
-
-
-class GlyphSelector:
-    def __init__(self, selector, suffixes, location):
-        self.selector = selector
-        self.suffixes = suffixes
-        self.location = location
-
-    def as_text(self):
-        if "barename" in self.selector:
-            returned = self.selector["barename"]
-        elif "classname" in self.selector:
-            returned = "@" + self.selector["classname"]
-        elif "regex" in self.selector:
-            returned = "/" + self.selector["regex"] + "/"
-        elif "unicodeglyph" in self.selector:
-            returned = "U+%04X" % self.selector["unicodeglyph"]
-        elif "unicoderange" in self.selector:
-            returned = "U+%04X=>U+%04X" % self.selector["unicoderange"].start, self.selector["unicoderange"].stop
-        elif "inlineclass" in self.selector:
-            items = [
-                GlyphSelector(i, (), self.location)
-                for i in self.selector["inlineclass"]
-            ]
-            returned = "[" + " ".join([item.as_text() for item in items]) + "]"
-
-        else:
-            raise ValueError("Unknown selector type %s" % self.selector)
-        for s in self.suffixes:
-            returned = returned + s["suffixtype"] + s["suffix"]
-        return returned
-
-    def _apply_suffix(self, glyphname, suffix):
-        if suffix["suffixtype"] == ".":
-            glyphname = glyphname + "." + suffix["suffix"]
-        else:
-            if glyphname.endswith("." + suffix["suffix"]):
-                glyphname = glyphname[: -(len(suffix["suffix"]) + 1)]
-        return glyphname
-
-    def resolve(self, fontfeatures, font, mustExist=True):
-        returned = []
-        assert isinstance(font, Font)
-        glyphs = font.exportedGlyphs()
-        if "barename" in self.selector:
-            returned = [self.selector["barename"]]
-        elif "unicodeglyph" in self.selector:
-            cp = self.selector["unicodeglyph"]
-            glyph = font.glyphForCodepoint(cp, fallback=False)
-            if not glyph:
-                raise ValueError(
-                    "Font does not contain glyph for U+%04X (at %s)"
-                    % (cp, self.location)
-                )
-            returned = [glyph]
-        elif "unicoderange" in self.selector:
-            returned = list(
-                collapse(
-                    [
-                        GlyphSelector({"unicodeglyph": i}, (), self.location).resolve(fontfeatures, font)
-                        for i in self.selector["unicoderange"]
-                    ]
-                )
-            )
-        elif "inlineclass" in self.selector:
-            returned = list(
-                collapse(
-                    [
-                        GlyphSelector(i, (), self.location).resolve(fontfeatures, font)
-                        for i in self.selector["inlineclass"]
-                    ]
-                )
-            )
-        elif "classname" in self.selector:
-            classname = self.selector["classname"]
-            if not classname in fontfeatures.namedClasses:
-                raise ValueError(
-                    "Tried to expand glyph class '@%s' but @%s was not defined (at %s)"
-                    % (classname, classname, self.location)
-                )
-            returned = fontfeatures.namedClasses[classname]
-        elif "regex" in self.selector:
-            regex = self.selector["regex"]
-            try:
-                pattern = re.compile(regex)
-            except Exception as e:
-                raise ValueError(
-                    "Couldn't parse regular expression '%s' at %s"
-                    % (regex, self.location)
-                )
-
-            returned = list(filter(lambda x: re.search(pattern, x), glyphs))
-        for s in self.suffixes:
-            returned = [self._apply_suffix(g, s) for g in returned]
-        if mustExist:
-            notFound = list(filter(lambda x: x not in glyphs, returned))
-            returned = list(filter(lambda x: x in glyphs, returned))
-            if len(notFound) > 0:
-                plural = ""
-                if len(notFound) > 1:
-                    plural = "s"
-                glyphstring = ", ".join(notFound)
-                warnings.warn(
-                    "# Couldn't find glyph%s '%s' in font (%s at %s)"
-                    % (plural, glyphstring, self.as_text(), self.location)
-                )
-        return list(returned)
-
-
-class FeeParser:
-    """Convert a FEE file into a fontFeatures object.
-
-    The resulting object is stored in the parser's ``fontFeatures`` property.
-
-    Args:
-        font: A TTFont object or glyphsLib GSFontMaster object.
-    """
-
-    basegrammar = """
-feefile = wsc statement+
-statement = verb:v wsc callRule(v "Args"):args ws ';' wsc -> parser.do(v, args)
-rest_of_line = <('\\\n' | (~'\n' anything))*>
-wsc = (comment | ' ' | '\t' | '\n')+ | ws
-comment = '#' rest_of_line ws?
-verb = <letter+>:x ?(x in self.valid_verbs) -> x
-
-# Ways of specifying glyphs
-classname = '@' barename:b -> {"classname": b["barename"]}
-
-startglyphname = anything:x ?(x in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
-midglyphname = anything:x ?(x in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-")
-# barename = <(letter|digit|"_"|'-')+>:b -> {"barename": b}
-barename = <startglyphname midglyphname*>:b -> {"barename": b}
-inlineclass_member = (barename|classname):m ws? -> m
-inlineclass_members = inlineclass_member+
-inlineclass = '[' ws inlineclass_members:m ']' -> {"inlineclass": m}
-regex = '/' <(~'/' anything)+>:r '/' -> {"regex": r}
-hexdigit = anything:x ?(x in '0123456789abcdefABCDEF') -> x
-unicodechar = 'U+' <hexdigit+>:u -> int(u,16)
-unicoderange = unicodechar:s '=>' unicodechar:e -> {"unicoderange": range(s,e+1)}
-unicodeglyphname = unicodechar:u -> {"unicodeglyph": u }
-glyphsuffix = ('.'|'~'):suffixtype <(letter|digit|"_")+>:suffix -> {"suffixtype":suffixtype, "suffix":suffix}
-glyphselector = ( unicoderange | unicodeglyphname | regex | barename | classname | inlineclass ):g glyphsuffix*:s -> GlyphSelector(g,s, self.input.position)
-
-# Number things
-bareinteger = ('-'|'+')?:sign <digit+>:i -> (-int(i) if sign == "-" else int(i))
-namedinteger = '$' barename:b ?(b["barename"] in parser.variables) -> int(parser.variables[b["barename"]])
-integer = namedinteger | bareinteger
-
-# Value records
-
-valuerecord = integer_value_record | fee_value_record | traditional_value_record
-integer_value_record = integer:xAdvance -> (0, 0, xAdvance, 0)
-traditional_value_record = '<' integer:xPlacement ws integer:yPlacement ws integer:xAdvance ws integer:yAdvance '>' -> (xPlacement, yPlacement, xAdvance, yAdvance)
-fee_value_record = '<' ws fee_value_record_member+:m '>' -> { "members": m }
-fee_value_record_member = ("xAdvance"| "xPlacement" | "yAdvance" | "yPlacement"):d '=' integer:pos ws -> {"dimension": d, "position": pos}
-
+    %import python(COMMENT)
+    %import common(LETTER, DIGIT, WS)
+    %ignore WS // this only omits whitespace not handled by other rules. e.g. between statements
+    %ignore COMMENT
 """
 
+HELPERS="""
+    statement: verb args ";"
+    verb: VERB
+    args: arg* | (arg* "{" statement* "}" arg*)
+    arg: ARG WS*
+
+    VERB: /[A-Z]/ (LETTER | DIGIT | "_")+
+    ARG: (/[^\s;]+/)
+
+    STARTGLYPHNAME: LETTER | DIGIT | "_"
+    MIDGLYPHNAME: STARTGLYPHNAME | "." | "-"
+    BARENAME: STARTGLYPHNAME MIDGLYPHNAME*
+    inlineclass: "[" (WS* (CLASSNAME | BARENAME))* "]"
+    CLASSNAME: "@" BARENAME
+
+    ANYTHING: /[^\s]/
+    REGEX: "/" ANYTHING* "/"
+
+    HEXDIGIT: /[0-9A-Fa-f]/
+    UNICODEGLYPH: "U+" HEXDIGIT~1..6
+    unicoderange: UNICODEGLYPH "=>" UNICODEGLYPH
+
+    SUFFIXTYPE: ("." | "~")
+    glyphsuffix: SUFFIXTYPE STARTGLYPHNAME+
+    glyphselector: (unicoderange | UNICODEGLYPH | REGEX | BARENAME | CLASSNAME | inlineclass) glyphsuffix*
+
+    valuerecord: SIGNED_NUMBER | fee_value_record | fea_value_record
+    fee_value_record: "<" ( FEE_VALUE_VERB "=" integer_container )+ ">"
+    FEE_VALUE_VERB: "xAdvance" | "xPlacement" | "yAdvance" | "yPlacement"
+    fea_value_record: "<" integer_container integer_container integer_container integer_container ">"
+
+    METRIC: "width" | "lsb" | "rsb" | "xMin" | "xMax" | "yMin" | "yMax" | "rise" | "fullwidth"
+    metric_comparison: METRIC COMPARATOR integer_container 
+    GLYPHVALUE: METRIC "[" BARENAME "]"
+
+    NAMEDINTEGER: "$" BARENAME
+    integer_container: NAMEDINTEGER | GLYPHVALUE | SIGNED_NUMBER
+    COMPARATOR: ">=" | "<=" | "==" | "<" | ">"
+
+    languages: "<<" (LANG "/" SCRIPT)+ ">>"
+    SCRIPT: LETTER~3..4 // TODO: Validate
+    LANG: LETTER~3..4 // TODO: Validate
+
+    %import common(ESCAPED_STRING, SIGNED_NUMBER, NUMBER, LETTER, DIGIT, WS)
+    %ignore WS
+"""
+
+# These are options usable by plugins to affect parsing. It is recommended to
+# leave use_helpers True in almost all cases, unless you want to handle parsing
+# of arguments at a low level in your plugin. The helpers parse things like
+# glyph classes, regular expressions, etc. in a consistent way across different
+# plugins.
+PARSEOPTS = dict(use_helpers=True)
+
+class NullParser:
+    def parse(*args, **kwargs):
+        pass
+
+class Verb:
+    transformer = None
+    parser = None
+
+class FeeParser:
     DEFAULT_PLUGINS = [
         "LoadPlugin",
         "ClassDefinition",
@@ -193,21 +96,62 @@ fee_value_record_member = ("xAdvance"| "xPlacement" | "yAdvance" | "yPlacement")
         "Variables",
     ]
 
+    plugins = dict()
+    variables = dict()
+    current_file = pathlib.Path().absolute()
+
+    parser = lark.Lark(HELPERS+GRAMMAR)
+
     def __init__(self, font):
-        self.grammar = self._make_initial_grammar()
-        self.grammar_generation = 1
+        for p in self.DEFAULT_PLUGINS:
+            self.load_plugin(p)
+
         self.font = font
+        self.transformer = FeeTransformer(self)
         self.fontfeatures = FontFeatures()
-        self.current_file = None
-        self.plugin_classes = {}
-        self.current_feature = None
-        self.font_modified = False
-        self.variables = {}
-        self._rebuild_parser()
-        # Set up GDEF table from font
         self.fontfeatures.setGlyphClassesFromFont(self.font)
-        for plugin in self.DEFAULT_PLUGINS:
-            self._load_plugin(plugin)
+
+    def load_plugin(self, plugin) -> bool:
+        if "." not in plugin:
+            resolved_plugin = "feeLib." + plugin
+
+        mod = import_module(resolved_plugin)
+
+        if not all([hasattr(mod, attr) for attr in ("PARSEOPTS", "GRAMMAR", "VERBS")]) or \
+                not "use_helpers" in mod.PARSEOPTS:
+            warnings.warn("Module {} is not a FEE plugin".format(resolved_plugin))
+            return False
+
+        return self.register_plugin(mod, plugin)
+
+    def register_plugin(self, mod, plugin) -> bool:
+        verbs = getattr(mod, "VERBS")
+        popts = getattr(mod, "PARSEOPTS")
+        rules = HELPERS+mod.GRAMMAR if popts["use_helpers"] else mod.GRAMMAR
+
+        for v in verbs:
+            verb = Verb()
+            verb_grammar = getattr(mod, v+"_GRAMMAR", None)
+            verb_bbgrammar = getattr(mod, v+"_beforebrace_GRAMMAR", None)
+            verb_abgrammar = getattr(mod, v+"_afterbrace_GRAMMAR", None)
+            
+            if verb_grammar:
+                verb.parser = lark.Lark(rules+verb_grammar)
+            else:
+                verb.parser = lark.Lark(rules)
+
+            if verb_bbgrammar:
+                verb.bbparser = lark.Lark(rules+verb_bbgrammar)
+            else:
+                verb.bbparser = NullParser()
+
+            if verb_abgrammar:
+                verb.abparser = lark.Lark(rules+verb_abgrammar)
+            else:
+                verb.abparser = NullParser()
+
+            verb.transformer = getattr(mod, v)
+            self.plugins[v] = verb
 
     def parseFile(self, filename):
         """Load a FEE features file.
@@ -226,53 +170,115 @@ fee_value_record_member = ("xAdvance"| "xPlacement" | "yAdvance" | "yPlacement")
         Args:
             s: Layout rules in FEE format.
         """
-        fee = self.parser(s).feefile()
-        if self.font_modified:
-            warnings.warn("Font was modified")
-        return fee
-
-    def _rebuild_parser(self):
-        self.parser = parsley.wrapGrammar(self.grammar)
-
-    def _make_initial_grammar(self):
-        g = parsley.makeGrammar(
-            FeeParser.basegrammar,
-            {"match": re.match, "GlyphSelector": GlyphSelector},
-            unwrap=True,
-        )
-        g.globals["parser"] = self
-        g.rule_callRule = callRule
-        g.valid_verbs = ["LoadPlugin"]
-        return g
-
-    def _load_plugin(self, plugin):
-        if "." not in plugin:
-            plugin = "fontFeatures.feeLib." + plugin
-        mod = importlib.import_module(plugin)
-        if not hasattr(mod, "GRAMMAR"):
-            warnings.warn("Module %s is not a FEE plugin" % plugin)
-            return
-
-        self._register_plugin(mod)
-
-    def _register_plugin(self, mod):
-        rules = mod.GRAMMAR
-        verbs = getattr(mod, "VERBS", [])
-        self.grammar_generation = self.grammar_generation + 1
-        classes = inspect.getmembers(mod, inspect.isclass)
-        self.grammar.valid_verbs.extend(verbs)
-        newgrammar = OMeta.makeGrammar(
-            rules, "Grammar%i" % self.grammar_generation
-        ).createParserClass(self.grammar, {})
-        newgrammar.globals = self.grammar.globals
-        for v in verbs:
-            self.grammar.globals[v] = newgrammar
-        for c in classes:
-            self.plugin_classes[c[0]] = c[1]
-        self._rebuild_parser()
-
-    def do(self, verb, args):
-        return self.plugin_classes[verb].action(self, *args)
+        return self.transformer.transform(self.parser.parse(s))
 
     def filterResults(self, results):
-        return [x for x in collapse(results) if x]
+        ret = [x for x in collapse(results) if x and not isinstance(x, str)]
+        return ret
+
+class FeeTransformer(lark.Transformer):
+    def __init__(self, parser):
+        self.parser = parser
+
+    def start(self, args):
+        return args 
+
+    def statement(self, args):
+        verb, args = args
+        #print("FeeTransformer.statement", verb, args)
+        if verb not in self.parser.plugins:
+            warnings.warn("Unknown verb: %s" % verb)
+            return (verb, args)
+
+        requested_plugin = self.parser.plugins[verb]
+
+        # This branch is called for plugins that use `statement` in their grammar (and use_helpers), it allows the statements to resolve themselves so you aren't given the args as a string. Most such plugins use brackets, e.g. Feature, Routine
+        tuple_idxs = list( (i for i,v in enumerate(args) if isinstance(v, tuple)) )
+        if len(tuple_idxs) > 0:
+            first_tuple_idx, last_tuple_idx = tuple_idxs[0], tuple_idxs[-1]
+            statements = [args[ti] for ti in tuple_idxs]
+            before = args[:first_tuple_idx]
+            after = args[last_tuple_idx+1:]
+            before_tree = requested_plugin.bbparser.parse(' '.join(before))
+            after_tree  = requested_plugin.abparser.parse(' '.join(after))
+            transformer = requested_plugin.transformer(self.parser)
+            ret = []
+            if before_tree:
+                before_args = transformer.transform(before_tree)
+                ret.insert(0, before_args if len(before_args) > 0 else None)
+            else:
+                ret.insert(0, None)
+            ret.append(statements)
+            if after_tree:
+                after_args  = transformer.transform(after_tree)
+                ret.append(after_args if len(after_args) > 0 else None)
+            else:
+                ret.append(None)
+            verb_ret = (verb, transformer.action(ret))
+        # For normal plugins that don't take statements
+        elif len(args) == 0 or isinstance(args[0], str):
+            tree = requested_plugin.parser.parse(' '.join(args))
+            verb_ret = (verb, requested_plugin.transformer(self.parser).transform(tree))
+        else:
+            raise ValueError("Arguments of unknown type: {}".format(type(args)))
+
+        #print("Parsed line...", verb_ret)
+        return verb_ret
+
+    def verb(self, args):
+        assert len(args) == 1
+        return args[0].value
+
+    def args(self, args):
+        return args
+
+    def arg(self, args):
+        return args[0].value
+
+def _UNICODEGLYPH(u):
+    return int(u[2:], 16)
+
+class HelperTransformer(lark.Transformer):
+    def __init__(self, parser):
+        self.parser = parser
+
+    def beforebrace(self, args):
+        return args
+
+    def SIGNED_NUMBER(self, tok):
+        return int(tok)
+
+    def NAMEDINTEGER(self, tok):
+        name = tok[1:] # all begin with $. but this doesn't match $1, $2 etc.
+        if name in self.parser.variables:
+            return self.parser.variables[name]
+        else:
+            return ValueError("Undefined variable: %s")
+
+    def GLYPHVALUE(self, args):
+        (metric, glyph) = args
+        return self._get_metrics(glyph, metric)
+
+    def glyphsuffix(self, args):
+        (suffixtype, suffix) = args[0].value, "".join([a.value for a in args[1:]])
+        return dict(suffixtype=suffixtype, suffix=suffix)
+
+    def integer_container(self, args):
+        (i,) = args
+        return int(i)
+
+    def unicoderange(self, args):
+        return lark.Token("UNICODERANGE", range(_UNICODEGLYPH(args[0].value), _UNICODEGLYPH(args[1].value)+1), args[0].pos_in_stream)
+
+    def inlineclass(self, args):
+        return lark.Token("INLINECLASS", [{t.type.lower(): t.value} for t in args if t.type in ["BARENAME", "CLASSNAME"]])
+
+    def glyphselector(self, args):
+        token, suffixes = args[0], args[1:]
+        if token.type == "CLASSNAME":
+            token.value = token.value[1:]
+        elif token.type == "REGEX":
+            token.value = token.value[1:-1]
+        elif token.type == "UNICODEGLYPH":
+            token.value = _UNICODEGLYPH(token.value)
+        return GlyphSelector({token.type.lower(): token.value}, suffixes, token.pos_in_stream)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ config = {
     'package_dir': {'fontFeatures': 'fontFeatures'},
     'packages': find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 ,
-    'scripts': scripts
+    'scripts': scripts,
+    'zip_safe': False
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
Close #8
Close #22
Close #26

This is still in progress. I mostly tested it by copying feeLib out of the repository up to my parent `~/Workspace`, then edited this script:

```python3
import feeLib

sample_file = """
#comment ca va
#   a
LoadPlugin ClassDefinition;
Include "test.fee";
LoadPlugin Anchors;
LoadPlugin Debug;
LoadPlugin Variables;
LoadPlugin Feature;
DefineClass @perp = zero;
DefineClass @lerp = /^g/;
DefineClass @yerp = /e$/;

LoadPlugin Position;
DefineClass @wide = width > 900;
DefineClass @thin = width < 300;

Feature ss03 {
    #Position @wide <30 -70 0 0> @thin;
    Position @wide <xPlacement=30 yPlacement=-70> @thin;
};

#DefineClass @low = a | c;
#DefineClass @low2 = a | c | e;
#DefineClass @QQ = @low2 | @lerp;
#DefineClass @derp = U+30->U+39;
#DefineClass @pred = f & hasglyph(/f/ g);
#DefineClass @wide_caps = /^[A-Z]$/ & width > 450;
#DefineClass @thin_caps = /^[A-Z]$/ & not width > 450;
#DefineClass @em = width == 1000;
#DefineClass @inline = [l o l]; # works because HelperTransformer in use
#ShowClass @wide_caps;
DefineClassBinned @bases[width,5] = /.*/;
#DumpClassNames;
#ShowClass @bases_width1;
#DumpClasses;
LoadPlugin Routine;
LoadPlugin Substitute;
Substitute a -> b <<cyrl/RUS>>;
#Anchors A _top <-570 1290> top <-570 1650>;

LoadAnchors;
Feature mark {
    Attach &top &_top bases;
};

Routine MEDIFINA {
    Substitute a -> b;
};

Set once = 11;

IDontExist @get @owned.hard [l o l] [@yes @no] [] [@QQ] U+20 @cluck~cluck.cluck;

Feature ss02 {
    LoadPlugin Conditional;
    If $once == 11 {
        Substitute Q -> D;
    };

    Routine {
    Substitute a -> b;
    Substitute b -> c;
    } MarkAttachmentType g;

    Routine qi {
    Substitute a -> b;
    Substitute b -> c;
    } IgnoreMarks;

    
    Substitute /^[a-z]$/ -> $1.low~low.high;
    ReverseSubstitute /^[a-z]$/ -> $1.low~low.high;

    #Routine {
    #    Substitute a -> b;
    #};


    LoadPlugin Chain;
    Routine {
    Chain a b (b ^qi a ^qi);
    } IgnoreMarks IgnoreLigatures;
};
"""

from fontTools.ttLib import TTFont
from babelfont import Babelfont
from fontFeatures.ttLib import unparse
font = Babelfont.open('/home/fred/.fonts/s/Some Time Later.otf')
#font = Babelfont.open('FRBAmericanCursive-300-Light.otf')

fp = feeLib.FeeParser(font)
ps = fp.parseString(sample_file)
print(fp.fontfeatures.asFea())

```

# What's done

[-] Lark parser in feeLib core
[-] Lark parser in all default plugins

# What's not done

[ ] Lark parser in non-default plugins
[ ] Documentation of some changes to grammars
[ ] Documentation of new way to write plugins