### PR TITLE
Add Routine.lookupType attribute support for Routine filtering

### DIFF
--- a/fontFeatures/__init__.py
+++ b/fontFeatures/__init__.py
@@ -364,6 +364,7 @@ class Routine:
         flags=0,
         markFilteringSet=None,
         markAttachmentSet=None,
+        lookupType="",
     ):
         self.name = name
         self.usecount = 0
@@ -380,6 +381,7 @@ class Routine:
         self.flags = flags
         self.markFilteringSet = markFilteringSet
         self.markAttachmentSet = markAttachmentSet
+        self.lookupType = lookupType
 
     def addRule(self, rule):
         """Adds a rule to a Routine.

--- a/fontFeatures/ttLib/GPOSUnparser.py
+++ b/fontFeatures/ttLib/GPOSUnparser.py
@@ -64,7 +64,10 @@ class GPOSUnparser(GTableUnparser):
 
     def unparseSinglePositioning(self, lookup):
         """Turn a GPOS1 (single positioning) subtable into a fontFeatures Routine."""
-        b = fontFeatures.Routine(name=self.getname("SinglePositioning" + self.gensym()))
+        b = fontFeatures.Routine(
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
+        )
         self._fix_flags(b, lookup)
 
         for subtable in lookup.SubTable:
@@ -90,7 +93,10 @@ class GPOSUnparser(GTableUnparser):
 
     def unparsePairPositioning(self, lookup):
         """Turn a GPOS2 (pair adjustment) subtable into a fontFeatures Routine."""
-        b = fontFeatures.Routine(name=self.getname("PairPositioning" + self.gensym()))
+        b = fontFeatures.Routine(
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
+        )
         self._fix_flags(b, lookup)
         for subtable in lookup.SubTable:
             if subtable.Format == 1:
@@ -133,7 +139,10 @@ class GPOSUnparser(GTableUnparser):
 
     def unparseCursiveAttachment(self, lookup):
         """Turn a GPOS3 (cursive attachment) subtable into a fontFeatures Routine."""
-        b = fontFeatures.Routine(name=self.getname("CursiveAttachment" + self.gensym()))
+        b = fontFeatures.Routine(
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
+        )
         self._fix_flags(b, lookup)
         entries = {}
         exits = {}
@@ -164,7 +173,10 @@ class GPOSUnparser(GTableUnparser):
 
     def unparseMarkToBase(self, lookup):
         """Turn a GPOS4 (mark to base) subtable into a fontFeatures Routine."""
-        b = fontFeatures.Routine(name=self.getname("MarkToBase" + self.gensym()))
+        b = fontFeatures.Routine(
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
+        )
         self._fix_flags(b, lookup)
         for subtable in lookup.SubTable:  # fontTools.ttLib.tables.otTables.MarkBasePos
             assert subtable.Format == 1
@@ -227,14 +239,20 @@ class GPOSUnparser(GTableUnparser):
 
     def unparseMarkToLigature(self, lookup):
         """Turn a GPOS5 (mark to ligature) subtable into a fontFeatures Routine."""
-        b = fontFeatures.Routine(name=self.getname("MarkToLigature" + self.gensym()))
+        b = fontFeatures.Routine(
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
+        )
         self._fix_flags(b, lookup)
         self.unparsable(b, "Mark to lig pos", lookup)
         return b, []
 
     def unparseMarkToMark(self, lookup):
         """Turn a GPOS6 (mark to mark) subtable into a fontFeatures Routine."""
-        b = fontFeatures.Routine(name=self.getname("MarkToMark" + self.gensym()))
+        b = fontFeatures.Routine(
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
+        )
         self._fix_flags(b, lookup)
         for subtable in lookup.SubTable:  # fontTools.ttLib.tables.otTables.MarkBasePos
             assert subtable.Format == 1
@@ -255,7 +273,7 @@ class GPOSUnparser(GTableUnparser):
                         font=self.font,
                         address=self.currentLookup,
                         flags=lookup.LookupFlag,
-                        force_markmark=True
+                        force_markmark=True,
                     )
                 )
         return b, []

--- a/fontFeatures/ttLib/GSUBUnparser.py
+++ b/fontFeatures/ttLib/GSUBUnparser.py
@@ -49,7 +49,8 @@ class GSUBUnparser(GTableUnparser):
     def unparseReverseContextualSubstitution(self, lookup):
         """Turn a GPOS8 (reverse contextual substitution) subtable into a fontFeatures Routine."""
         b = fontFeatures.Routine(
-            name=self.getname("ReverseContextualSubstitution" + self.gensym())
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
         )
         self._fix_flags(b, lookup)
         for sub in lookup.SubTable:
@@ -79,7 +80,8 @@ class GSUBUnparser(GTableUnparser):
     def unparseLigatureSubstitution(self, lookup):
         """Turn a GPOS4 (ligature substitution) subtable into a fontFeatures Routine."""
         b = fontFeatures.Routine(
-            name=self.getname("LigatureSubstitution" + self.gensym())
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
         )
         self._fix_flags(b, lookup)
         for sub in lookup.SubTable:
@@ -101,7 +103,8 @@ class GSUBUnparser(GTableUnparser):
     def unparseMultipleSubstitution(self, lookup):
         """Turn a GPOS2 (multiple substitution) subtable into a fontFeatures Routine."""
         b = fontFeatures.Routine(
-            name=self.getname("MultipleSubstitution" + self.gensym())
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
         )
         self._fix_flags(b, lookup)
 
@@ -120,7 +123,8 @@ class GSUBUnparser(GTableUnparser):
     def unparseAlternateSubstitution(self, lookup):
         """Turn a GPOS3 (alternate substitution) subtable into a fontFeatures Routine."""
         b = fontFeatures.Routine(
-            name=self.getname("AlternateSubstitution" + self.gensym())
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
         )
         self._fix_flags(b, lookup)
         for sub in lookup.SubTable:
@@ -139,7 +143,8 @@ class GSUBUnparser(GTableUnparser):
     def unparseSingleSubstitution(self, lookup):
         """Turn a GPOS1 (single substitution) subtable into a fontFeatures Routine."""
         b = fontFeatures.Routine(
-            name=self.getname("SingleSubstitution" + self.gensym())
+            name=self.getname(self.get_lookuptype_str(lookup) + self.gensym()),
+            lookupType=self.get_lookuptype_str(lookup),
         )
         self._fix_flags(b, lookup)
         for sub in lookup.SubTable:

--- a/fontFeatures/ttLib/GTableUnparser.py
+++ b/fontFeatures/ttLib/GTableUnparser.py
@@ -215,7 +215,7 @@ class GTableUnparser:
         """Handles extension lookups by recursing into them."""
         routines = []
         dependencies = []
-        ext_lookup_type = None
+        ext_lookup_type = ""
         for xt in lookup.SubTable:
             xt.SubTable = [xt.ExtSubTable]
             xt.LookupType = xt.ExtSubTable.LookupType


### PR DESCRIPTION
Closes #45

Changes:

- adds `Extension*` prefixed unique name definition on the `Routine.name` attribute for extension routine sub-classes
- adds new `Routine.lookupType` attribute and definition support in all lookup unparsing methods

I ended up implementing a new `lookupType` attribute on the Routine object with the following rationale:

1.  simplifies Routine filtering across all lookup types
2. extends extension routine types with more information to understand the lookup type in the extension

### Example data structure to support 1

No longer requires unique `name` attribute prefix string parsing.

```python
{'address': None,
 'comments': [],
 'flags': 0,
 'inlined': False,
 'languages': [('DFLT', 'dflt'), ('cyrl', 'dflt'), ('latn', 'dflt')],
 'lookupType': 'MarkToBase',
 'markAttachmentSet': None,
 'markFilteringSet': None,
 'name': 'MarkToBase3',
 'parent': None,
 'rules': [<fontFeatures.Attachment object at 0x113ed0bb0>,
           <fontFeatures.Attachment object at 0x114478070>,
           <fontFeatures.Attachment object at 0x1144780a0>,
           <fontFeatures.Attachment object at 0x1144780d0>,
           <fontFeatures.Attachment object at 0x114478100>],
 'usecount': 0,
 'usedin': set()}
{'address': None,
 'comments': [],
 'flags': 0,
 'inlined': False,
 'languages': [('DFLT', 'dflt'), ('cyrl', 'dflt'), ('latn', 'dflt')],
 'lookupType': 'MarkToBase',
 'markAttachmentSet': None,
 'markFilteringSet': None,
 'name': 'MarkToBase9',
 'parent': None,
 'rules': [<fontFeatures.Attachment object at 0x113ed0b50>,
           <fontFeatures.Attachment object at 0x114478160>,
           <fontFeatures.Attachment object at 0x114478190>,
           <fontFeatures.Attachment object at 0x1144781c0>,
           <fontFeatures.Attachment object at 0x1144781f0>],
 'usecount': 0,
 'usedin': set()}
{'address': None,
 'comments': [],
 'flags': 256,
 'inlined': False,
 'languages': [('DFLT', 'dflt'), ('cyrl', 'dflt'), ('latn', 'dflt')],
 'lookupType': 'MarkToMark',
 'markAttachmentSet': ['dotbelowcomb',
                       'uni0324',
                       'uni0326',
                       'uni0327',
                       'uni032E',
                       'uni0331'],
 'markFilteringSet': None,
 'name': 'MarkToMark22',
 'parent': None,
 'rules': [<fontFeatures.Attachment object at 0x114478220>],
 'usecount': 0,
 'usedin': set()}
```

```python
tt = TTFont(fontpath)
ff = fontFeatures.ttLib.unparse(tt)
mark2mark = [ routine for routine in ff.routines if routine.lookupType == "MarkToMark" ]
mark2base = [ routine for routine in ff.routines if routine.lookupType == "MarkToBase" ]

for routine in mark2mark:
    # do things

for routine in mark2base:
    # do things
```


### Example data structure to support 2

No longer matters if the lookup rules are in an extension or not, the lookup type is categorized under the `lookupType` attribute.

```python
{'address': None,
 'comments': [],
 'flags': 0,
 'inlined': False,
 'languages': [('DFLT', 'dflt'), ('cyrl', 'dflt'), ('latn', 'dflt')],
 'lookupType': 'MarkToBase',
 'markAttachmentSet': None,
 'markFilteringSet': None,
 'name': 'MarkToBase3',
 'parent': None,
 'rules': [<fontFeatures.Attachment object at 0x11bccdc10>,
           <fontFeatures.Attachment object at 0x11c2750d0>,
           <fontFeatures.Attachment object at 0x11c275100>,
           <fontFeatures.Attachment object at 0x11c275130>,
           <fontFeatures.Attachment object at 0x11c275160>],
 'usecount': 0,
 'usedin': set()}
{'address': None,
 'comments': [],
 'flags': 0,
 'inlined': False,
 'languages': [('DFLT', 'dflt'), ('cyrl', 'dflt'), ('latn', 'dflt')],
 'lookupType': 'MarkToBase',
 'markAttachmentSet': None,
 'markFilteringSet': None,
 'name': 'MarkToBase9',
 'parent': None,
 'rules': [<fontFeatures.Attachment object at 0x11bccdbb0>,
           <fontFeatures.Attachment object at 0x11c2751c0>,
           <fontFeatures.Attachment object at 0x11c2751f0>,
           <fontFeatures.Attachment object at 0x11c275220>,
           <fontFeatures.Attachment object at 0x11c275250>],
 'usecount': 0,
 'usedin': set()}
{'address': None,
 'comments': [],
 'flags': 0,
 'inlined': False,
 'languages': [('DFLT', 'dflt'), ('cyrl', 'dflt'), ('latn', 'dflt')],
 'lookupType': 'MarkToBase',
 'markAttachmentSet': None,
 'markFilteringSet': None,
 'name': 'Extension21',
 'parent': None,
 'rules': [<fontFeatures.Attachment object at 0x11c275190>,
           <fontFeatures.Attachment object at 0x11c2752e0>,
           <fontFeatures.Attachment object at 0x11c275310>,
           <fontFeatures.Attachment object at 0x11c275340>,
           <fontFeatures.Attachment object at 0x11c275370>],
 'usecount': 0,
 'usedin': set()}
```

```python
tt = TTFont(fontpath)
ff = fontFeatures.ttLib.unparse(tt)
mark2base  = [ routine for routine in ff.routines if routine.lookupType == "MarkToBase" ]

for routine in mark2base:
    # do things
```


