### PR TITLE
Fix crash on missing named lookup in chaining substitution rule

### DIFF
--- a/fontFeatures/__init__.py
+++ b/fontFeatures/__init__.py
@@ -321,6 +321,8 @@ class FontFeatures:
         self.routines[index : index + 1] = allroutines
         for user in usedin:
             for lookuplist in user.lookups:
+                if lookuplist is None:
+                    continue
                 i = 0
                 while i < len(lookuplist):
                     lookup = lookuplist[i]
@@ -334,6 +336,8 @@ class FontFeatures:
                     i = i + 1
         # Same trick for features
         for lookuplist in self.features.values():
+            if lookuplist is None:
+                continue
             i = 0
             while i < len(lookuplist):
                 lookup = lookuplist[i]


### PR DESCRIPTION
otf2fea with fontFeatures 1.3.0 crashes when a glyph in a chaining substitution rule has no lookups applied to it.
```console
$ curl -LOs https://github.com/googlefonts/noto-fonts/raw/29aa92a9a0768be2d58cf4c590adb5c18b8247c6/unhinted/otf/NotoSerifDevanagari/NotoSerifDevanagari-Regular.otf
$ otf2fea NotoSerifDevanagari-Regular.otf
Traceback (most recent call last):
  File "/usr/local/bin/otf2fea", line 70, in <module>
    print(ff.asFea())
  File "/usr/local/lib/python3.9/site-packages/fontFeatures/feaLib/FontFeatures.py", line 21, in asFea
    return self.asFeaAST(**kwargs).asFea()
  File "/usr/local/lib/python3.9/site-packages/fontFeatures/feaLib/FontFeatures.py", line 97, in asFeaAST
    partitioned = self.partitionRoutine(routine,
  File "/usr/local/lib/python3.9/site-packages/fontFeatures/__init__.py", line 315, in partitionRoutine
    return self.replaceRoutineWithSplitList(routine, allroutines)
  File "/usr/local/lib/python3.9/site-packages/fontFeatures/__init__.py", line 325, in replaceRoutineWithSplitList
    while i < len(lookuplist):
TypeError: object of type 'NoneType' has no len()
```
With this fix, the offending lookup is converted correctly:
```fea
lookup Extension806 {
    lookupflag 0;
    ;
    # Original source: 792
    sub [uni090B uni0960]' uni0930094D' lookup LigatureSubstitution48 [uni0902 uni0901]';
} Extension806;
```