### PR TITLE
Fix involved_glyphs union for empty rules

### DIFF
--- a/fontFeatures/__init__.py
+++ b/fontFeatures/__init__.py
@@ -413,7 +413,7 @@ class Routine:
     @property
     def involved_glyphs(self):
         """Returns the names of all of the glyphs involved in this Routine."""
-        return set.union(*[r.involved_glyphs for r in self.rules])
+        return set().union(*(r.involved_glyphs for r in self.rules))
 
     @property
     def stage(self):


### PR DESCRIPTION
Class method `set.union` fails if argument is empty (in case of missing rules).

Also replace list comprehension with generator expression.