### PR TITLE
Fix failing test in test_anchors

### DIFF
--- a/tests/test_anchors.py
+++ b/tests/test_anchors.py
@@ -22,8 +22,8 @@ class TestAnchors(unittest.TestCase):
       self.assertEqual(rt.asFea(), thing.asFea())
 
     def test_markbase(self):
-        s = Attachment("top", "top_", {"A": (679, 1600)}, {"acutecomb": (-570, 1290)})
-        assertSufficientlyEqual(s.asFea(), "    pos base A <anchor 679 1600> mark @top;\n")
+        s = Attachment("top", "top_", bases={"A": (679, 1600)}, marks={"acutecomb": (-570, 1290)})
+        assertSufficientlyEqual(s.asFea(), "    pos base A <anchor 679 1600> mark @top_top_;\n")
         self.assertEqual(s.involved_glyphs, set(["A", "acutecomb"]))
         self.assertEqual(etree.tostring(s.toXML()), '<attachment basename="top" markname="top_"><base name="A" anchorX="679" anchorY="1600"/><mark name="acutecomb" anchorX="-570" anchorY="1290"/></attachment>'.encode("utf-8"))
         self.roundTrip(s)


### PR DESCRIPTION
As you may notice we still have a test fail. I'm not sure how to fix it as the results are identical, markClass names shouldn't matter to a roundtrip?