### PR TITLE
maintenance: CI fix, upgrades and compatibility with babelfont API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10, 3.11, 3.12]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 coverage_html
 htmlcov
-*.pyc 
+*.pyc
 build
 docs
 fontFeatures.egg-info
@@ -15,3 +15,5 @@ dist
 *.ttx
 *.test
 *.json
+
+.venv

--- a/fontFeatures/__init__.py
+++ b/fontFeatures/__init__.py
@@ -279,7 +279,7 @@ class FontFeatures:
 
     def setGlyphClassesFromFont(self, font):
         """Loads glyph classes from the font."""
-        for g in font.exportedGlyphs():
+        for g in font.exported_glyphs():
             if hasattr(font, "glyphs"):
                 self.glyphclasses[g] = font.glyphs[g].category
             else:

--- a/fontFeatures/shaperLib/Buffer.py
+++ b/fontFeatures/shaperLib/Buffer.py
@@ -67,8 +67,8 @@ class BufferItem:
 
     def prep_glyph(self, font):
         if "pytest" in sys.modules:
-            if self.glyph in font.exportedGlyphs():
-                self.gid = font.exportedGlyphs().index(self.glyph)
+            if self.glyph in font.exported_glyphs():
+                self.gid = font.exported_glyphs().index(self.glyph)
             else:
                 self.gid = -1  # ?
         self.substituted = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fs
-fontTools>=4.28.0
+fontTools>=4.54.0
 lxml


### PR DESCRIPTION
* Updated the Python versions in the CI to include 3.10, 3.11, and 3.12, and upgraded `actions/checkout` and `actions/setup-python` to the latest versions.
* Changed method call from `font.exportedGlyphs()` to `font.exported_glyphs()`   for compatibility with babelfont library. 