### PR TITLE
Build AlternateSubst rule

### DIFF
--- a/fontFeatures/ttLib/Routine.py
+++ b/fontFeatures/ttLib/Routine.py
@@ -179,6 +179,10 @@ def buildSub(self, font, lookuptype, ff):
         builder = otl.MultipleSubstBuilder(font, self.address)
         for rule in self.rules:
             builder.mapping[rule.input[0][0]] = [x[0] for x in rule.replacement]
+    elif lookuptype == 3:
+        builder = otl.AlternateSubstBuilder(font, self.address)
+        for rule in self.rules:
+            builder.alternates[rule.input[0][0]] = rule.replacement[0]
     elif lookuptype == 4:
         builder = otl.LigatureSubstBuilder(font, self.address)
         for rule in self.rules:


### PR DESCRIPTION
This addresses the _direct issue_ in #69, in that buildBinaryFeatures can now be called without an Exception, but i haven't investigated the output yet, and i don't know if it's right.

There was some guesswork around what the contents of the `.input` and `.replacement` attributes is. The current code is an improvement on my first guess, but still something of a guess. At least my own `fext` tool suggests that it is plausible.